### PR TITLE
Tatt inn "hero" som valgfritt seksjonselement

### DIFF
--- a/schemas/selvstendig-naerinsgdrivende/page-section.js
+++ b/schemas/selvstendig-naerinsgdrivende/page-section.js
@@ -21,6 +21,7 @@ export default {
         { type: "linkBox" },
         { type: "contentBox" },
         { type: "expandingBox" },
+        { type: "hero" },
         {
           type: "reference",
           title: "Varselstripe",


### PR DESCRIPTION
Lagt inn "hero"-type som valgfritt element under schema'et til sectionContent. Dette åpner for at man kan gjenbruke "hero"-komponenten til andre formål i resten av siden — dagens ønske er å lage verdens korteste FAQ oppi en sånn boks. Kommer også til å foreslå endringer i beskrivelsesfeltet til "hero" men dét tar jeg der borte :)